### PR TITLE
GH-5: Update for default branch rename to main (resolves #5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [12.x, 14.x]
 
     env:
       HEADLESS: true

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ fluid.defaults("my.launcher", {
 });
 ```
 
-The contents of this file will be loaded using the [configuration loading built into kettle](https://github.com/fluid-project/kettle/blob/master/docs/ConfigsAndApplications.md).
+The contents of this file will be loaded using the [configuration loading built into kettle](https://github.com/fluid-project/kettle/blob/main/docs/ConfigsAndApplications.md).
 The file is expected to correspond roughly to a component definition, but supports additional options for including
 other configuration files.
 
@@ -79,7 +79,7 @@ be a part of the constructed grade name, and will appear in log messages, so a u
 options are being used for a given launch.  If `type` is omitted, it will be replace with a generated ID, which makes
 troubleshooting more difficult.
 
-See [the kettle documentation](https://github.com/fluid-project/kettle/blob/master/docs/ConfigsAndApplications.md#structure-of-a-kettle-config
+See [the kettle documentation](https://github.com/fluid-project/kettle/blob/main/docs/ConfigsAndApplications.md#structure-of-a-kettle-config
 ) for more details about the configuration file format, including the special keywords that support merging material
 from other configuration files.
 


### PR DESCRIPTION
Also updated CI to run against latest LTS versions of Node

Resolves #5 